### PR TITLE
fix: don't brick the app for accounts with a null displayName

### DIFF
--- a/src/layouts/AppLayout/AppLayout.tsx
+++ b/src/layouts/AppLayout/AppLayout.tsx
@@ -34,7 +34,10 @@ const AppLayout = ({
   const userAvatar = useAppSelector(selectUserAvatar);
   const autoLogInFailed = useAppSelector(selectAutoLogInFailed);
 
-  const isAuthenticated = !!(userAuth && userStats && userName);
+  // userName intentionally NOT required here: accounts with a null displayName
+  // in their users doc would otherwise be stuck on the loading screen forever
+  // (auth + stats loaded, no redirect fires, nothing ever fills the name).
+  const isAuthenticated = !!(userAuth && userStats);
 
   useEffect(() => {
     if (status === "unauthenticated" && !isPublic) {
@@ -78,7 +81,7 @@ const AppLayout = ({
       variant={variant}
       wide={wide}
       userStats={userStats}
-      userName={userName}
+      userName={userName ?? ""}
       userAvatar={userAvatar}>
       {children}
     </MainLoggedLayout>

--- a/src/pages/api/user/getUserData/index.ts
+++ b/src/pages/api/user/getUserData/index.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next";
 import { todayKey } from "lib/email/cooldown";
 import { markCooldown } from "lib/email/cooldownStore";
 import { sendWelcomeEmail } from "lib/email/send";
+import type { NextApiRequest, NextApiResponse } from "next";
 import { firestore } from "utils/firebase/api/firebase.config";
 
 const statisticsInitial = {
@@ -65,13 +65,19 @@ export default async function handler(
       const userSnapshotFresh = await userDocRef.get();
       const userData = userSnapshotFresh.data();
 
-      if (userData && !userData.email && user.email) {
-        await userDocRef.update({ email: user.email });
+      if (userData) {
+        const backfill: Record<string, string> = {};
+        if (!userData.email && user.email) backfill.email = user.email;
+        if (!userData.displayName && user.displayName)
+          backfill.displayName = user.displayName;
+        if (Object.keys(backfill).length > 0) {
+          await userDocRef.update(backfill);
+        }
       }
 
       return res.status(200).json({
         userInfo: {
-          displayName: userData?.displayName ?? null,
+          displayName: userData?.displayName ?? user.displayName ?? null,
           avatar: userData?.avatar ?? null,
           youTubeLink: userData?.youTubeLink ?? null,
           soundCloudLink: userData?.soundCloudLink ?? null,


### PR DESCRIPTION
An account whose users doc has displayName: null passed login fully (userAuth + userStats loaded), but AppLayout required userName for isAuthenticated and rendered an infinite loading screen with no redirect and no recovery - on every browser and device, forever.

- AppLayout: gate on userAuth + userStats only; a missing display name must not block the whole app.
- getUserData: backfill missing displayName from the auth user (same pattern as the existing email backfill) and fall back to user.displayName in the response.