### PR TITLE
feat(arsenal): pay Fame for Rig Level

### DIFF
--- a/src/feature/arsenal/ArsenalView.tsx
+++ b/src/feature/arsenal/ArsenalView.tsx
@@ -55,6 +55,7 @@ import { TraderView } from "./components/Trader/TraderView";
 import { WorkshopSkeleton } from "./components/Workshop/WorkshopSkeleton";
 import { WorkshopTab } from "./components/Workshop/WorkshopTab";
 import { CASE_DEFINITIONS } from "./data/caseDefinitions";
+import { formatRigFameRate, getRigFameRate } from "./data/rigFame";
 import { getRigLevel } from "./data/rigLevel";
 import { useArsenalData } from "./hooks/useArsenalData";
 import { useOpenCase } from "./hooks/useOpenCase";
@@ -65,6 +66,7 @@ export const ArsenalView = () => {
   const userStats = useAppSelector(selectCurrentUserStats);
   const fame = userStats?.fame || 0;
   const rigLevel = getRigLevel(data);
+  const rigFameRate = getRigFameRate(rigLevel);
 
   // Tab is URL-driven (?tab=market) so notifications/links can deep-link to it.
   const router = useRouter();
@@ -112,10 +114,20 @@ export const ArsenalView = () => {
               <span className="text-xl font-black text-amber-400">{fame.toLocaleString()}</span>
               <span className="text-xs text-zinc-400">Fame Points</span>
             </div>
-            <div className="flex items-center gap-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 px-4 py-2">
-              <Swords size={16} className="text-cyan-400" />
-              <span className="text-lg font-black text-cyan-300 tabular-nums">{rigLevel}</span>
-              <span className="text-xs text-zinc-400">Rig Level</span>
+            {/* The rate sits inside the Rig Level chip rather than beside it:
+                it is what that number does, so reading them apart would hide
+                the only causal link the Arsenal has to Fame. */}
+            <div className="flex flex-col gap-1 rounded-lg bg-cyan-500/10 border border-cyan-500/20 px-4 py-2">
+              <div className="flex items-center gap-2">
+                <Swords size={16} className="text-cyan-400" />
+                <span className="text-lg font-black text-cyan-300 tabular-nums">{rigLevel}</span>
+                <span className="text-xs text-zinc-400">Rig Level</span>
+              </div>
+              {rigFameRate > 0 && (
+                <span className="text-[11px] font-medium text-emerald-400 tabular-nums">
+                  +{formatRigFameRate(rigLevel)} Fame / h of practice
+                </span>
+              )}
             </div>
           </div>
         }

--- a/src/feature/arsenal/data/rigFame.test.ts
+++ b/src/feature/arsenal/data/rigFame.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cumulativeRigFame,
+  formatRigFameRate,
+  getRigFameRate,
+  RIG_FAME_HOURLY_CEILING,
+} from "./rigFame";
+
+describe("getRigFameRate", () => {
+  it("pays nothing without a rig", () => {
+    expect(getRigFameRate(0)).toBe(0);
+    expect(getRigFameRate(-50)).toBe(0);
+    expect(getRigFameRate(NaN)).toBe(0);
+  });
+
+  it("follows the published table", () => {
+    // The numbers the design was signed off on — 1 decimal, as the UI prints it.
+    expect(getRigFameRate(100).toFixed(1)).toBe("13.3");
+    expect(getRigFameRate(150).toFixed(1)).toBe("18.0");
+    expect(getRigFameRate(200).toFixed(1)).toBe("22.3");
+    expect(getRigFameRate(400).toFixed(1)).toBe("37.6");
+    expect(getRigFameRate(750).toFixed(1)).toBe("60.2");
+  });
+
+  it("keeps paying for the top of the ladder", () => {
+    // The whole reason the hyperbolic shape was dropped: 500 → 750 has to be
+    // worth real Fame, not the ~2/h an asymptote left it with.
+    const gain = getRigFameRate(750) - getRigFameRate(500);
+
+    expect(gain).toBeGreaterThan(15);
+  });
+
+  it("moves on every single level — no tiers", () => {
+    for (const level of [100, 250, 473, 600]) {
+      expect(getRigFameRate(level + 1)).toBeGreaterThan(getRigFameRate(level));
+    }
+  });
+
+  it("never goes backwards", () => {
+    for (let level = 1; level <= 1200; level++) {
+      expect(getRigFameRate(level)).toBeGreaterThanOrEqual(getRigFameRate(level - 1));
+    }
+  });
+
+  it("has diminishing but never dead returns", () => {
+    const low = getRigFameRate(101) - getRigFameRate(100);
+    const high = getRigFameRate(751) - getRigFameRate(750);
+
+    expect(high).toBeLessThan(low);
+    // At the top of the ladder a level is still worth more than half what it is
+    // at the average rig — the property the tiered and hyperbolic shapes lost.
+    expect(high).toBeGreaterThan(low * 0.5);
+  });
+
+  it("clamps an absurd rig to the ceiling", () => {
+    expect(getRigFameRate(1_000_000)).toBe(RIG_FAME_HOURLY_CEILING);
+  });
+
+  it("leaves today's top rig well under the ceiling", () => {
+    // The ceiling is a backstop against uncapped buildLevel, not a balance lever.
+    expect(getRigFameRate(750)).toBeLessThan(RIG_FAME_HOURLY_CEILING);
+  });
+});
+
+describe("cumulativeRigFame", () => {
+  it("pays nothing without a rig", () => {
+    expect(cumulativeRigFame(60, 0)).toBe(0);
+  });
+
+  it("pays nothing for an empty session", () => {
+    expect(cumulativeRigFame(0, 750)).toBe(0);
+  });
+
+  it("follows the published table for a typical rig", () => {
+    expect(cumulativeRigFame(5, 400)).toBe(3);
+    expect(cumulativeRigFame(15, 400)).toBe(9);
+    expect(cumulativeRigFame(25, 400)).toBe(16);
+    expect(cumulativeRigFame(30, 400)).toBe(19);
+    expect(cumulativeRigFame(60, 400)).toBe(38);
+  });
+
+  it("pays an hour of practice exactly the rate it advertises", () => {
+    // The property the minutes cap broke, and the reason it was removed: a rig
+    // whose card reads "30.1 Fame/h" has to hand back 30 for an hour practised.
+    for (const level of [150, 400, 750]) {
+      expect(cumulativeRigFame(60, level)).toBe(
+        Math.round(getRigFameRate(level))
+      );
+    }
+  });
+
+  it("keeps paying past an hour, in proportion to the time", () => {
+    // No taper: unlike the practice curve this is linear all the way out, which
+    // is the trade the removed cap was buying. Checked against the exact rate
+    // rather than a multiple of the rounded hour, which rounding shifts by one.
+    const rate = getRigFameRate(750);
+
+    expect(cumulativeRigFame(120, 750)).toBe(Math.round(rate * 2));
+    expect(cumulativeRigFame(240, 750)).toBe(Math.round(rate * 4));
+  });
+
+  it("never goes backwards", () => {
+    for (let minutes = 1; minutes <= 120; minutes++) {
+      expect(cumulativeRigFame(minutes, 400)).toBeGreaterThanOrEqual(
+        cumulativeRigFame(minutes - 1, 400)
+      );
+    }
+  });
+
+  it("treats negative minutes as zero", () => {
+    expect(cumulativeRigFame(-30, 750)).toBe(0);
+  });
+
+  it("gives splitters no advantage over one session", () => {
+    const steps = [10, 20, 30, 40, 50, 60];
+    let previous = 0;
+    let total = 0;
+
+    for (const minutes of steps) {
+      total += cumulativeRigFame(minutes, 600) - cumulativeRigFame(previous, 600);
+      previous = minutes;
+    }
+
+    expect(total).toBe(cumulativeRigFame(60, 600));
+  });
+
+  it("scales with the rig at a fixed session length", () => {
+    expect(cumulativeRigFame(25, 750)).toBeGreaterThan(cumulativeRigFame(25, 400));
+    expect(cumulativeRigFame(25, 400)).toBeGreaterThan(cumulativeRigFame(25, 150));
+  });
+});
+
+describe("formatRigFameRate", () => {
+  it("prints one decimal so every level shows", () => {
+    expect(formatRigFameRate(473)).toBe("42.6");
+    expect(formatRigFameRate(0)).toBe("0.0");
+  });
+});

--- a/src/feature/arsenal/data/rigFame.ts
+++ b/src/feature/arsenal/data/rigFame.ts
@@ -1,0 +1,91 @@
+/**
+ * What the rig pays on top of the practice curve.
+ *
+ * Rig Level used to do nothing but order the gear leaderboard: a player could
+ * sink hundreds of Fame and a stash of parts into builds and mods and the number
+ * moved without ever changing what the game paid them. This turns it into a
+ * rate — Fame per hour of practice — so every build, mod and better guitar has a
+ * price the player can read off the card before they pay it.
+ *
+ * Three decisions worth spelling out, because each replaced something worse:
+ *
+ *  • **A power curve, not a hyperbola.** An asymptotic `max · r/(r+k)` shape put
+ *    the whole live range inside its own flat tail — with the top rig in the game
+ *    at ~750 and the average at 100–200, going from 500 to 750 was worth under
+ *    2 Fame/h, so the last stretch of the ladder paid nothing. `r^0.75` keeps
+ *    rising: the same 500 → 750 climb is worth ~8 Fame/h, and one extra level is
+ *    worth 60% as much at rig 750 as it is at rig 100 (versus a tenth under the
+ *    hyperbola). Diminishing, never dead.
+ *
+ *  • **No tiers.** Bracketed rates (every 100 levels) meant nothing happened
+ *    between the brackets: three quarters of the work bought a number that did
+ *    not move. Continuous means every single level ticks the rate up.
+ *
+ *  • **Every minute counts.** An earlier draft paid only the day's first half
+ *    hour. That bounded the payout, but it made the headline rate a lie: a rig
+ *    advertising "8.7 Fame/h" handed back 4 Fame for an hour practised, and that
+ *    gap is the first thing anyone noticed. A rate the UI states has to be the
+ *    rate the game pays, so the clamp is gone.
+ *
+ *    The trade is deliberate and worth knowing: unlike `cumulativeDailyFame` this
+ *    does not flatten, so a four-hour day at the top rig pays four times a
+ *    one-hour day rather than tapering. `RIG_FAME_COEFF` is the knob if that ever
+ *    needs pulling back.
+ *
+ * Deliberately dependency-free: `calculateSessionFame` imports this, and pulling
+ * `getRigLevel` in here would drag every guitar and effect definition into the
+ * report bundle. Callers pass the level they already have.
+ */
+
+/**
+ * Scales the whole table without changing its shape — the tuning knob.
+ *
+ * Doubled from an initial 0.21, which made the rig read as decoration: the average
+ * rig paid 4 Fame for a 25-minute session against a practice curve of 15, so the
+ * one number the whole Arsenal feeds was worth about a quarter of just showing up.
+ */
+export const RIG_FAME_COEFF = 0.42;
+
+/** Curvature. Owns the top-end payoff; leave it alone when rebalancing. */
+export const RIG_FAME_EXPONENT = 0.75;
+
+/**
+ * Backstop, not a balance lever — nothing in the game reaches it today (the top
+ * rig pays ~60/h). `buildLevel` is uncapped and promotions compound, so without
+ * this a rig of 4000 would quietly pay 200/h a year from now.
+ */
+export const RIG_FAME_HOURLY_CEILING = 90;
+
+/**
+ * Fame per hour of practice this rig is worth. Continuous in `rigLevel`, so it
+ * moves on every point — which is what makes it worth previewing on a mod.
+ */
+export const getRigFameRate = (rigLevel: number): number => {
+  if (!Number.isFinite(rigLevel) || rigLevel <= 0) return 0;
+
+  return Math.min(
+    RIG_FAME_HOURLY_CEILING,
+    RIG_FAME_COEFF * rigLevel ** RIG_FAME_EXPONENT,
+  );
+};
+
+/**
+ * Cumulative rig Fame owed for `minutes` practised in one day.
+ *
+ * Monotone in `minutes`, so — exactly like `cumulativeDailyFame` — the difference
+ * between two calls is never negative and splitting a day into many reports pays
+ * the same as filing one.
+ */
+export const cumulativeRigFame = (
+  minutes: number,
+  rigLevel: number,
+): number => {
+  const rate = getRigFameRate(rigLevel);
+  if (rate <= 0) return 0;
+
+  return Math.round((rate * Math.max(0, minutes)) / 60);
+};
+
+/** The rate as the UI prints it — one decimal, so every level visibly moves it. */
+export const formatRigFameRate = (rigLevel: number): string =>
+  getRigFameRate(rigLevel).toFixed(1);

--- a/src/feature/user/view/ReportView/ReportView.types.tsx
+++ b/src/feature/user/view/ReportView/ReportView.types.tsx
@@ -61,6 +61,8 @@ export interface ReportDataInterface {
   fameStreakBonus?: number;
   /** Whether the high-accuracy multiplier applied to this session's fame. */
   fameAccuracyBonus?: boolean;
+  /** Fame the user's rig paid for this session, already included in `fameEarned`. */
+  fameRigBonus?: number;
   bonusPoints: {
     multiplier: number;
     habitsCount: number;

--- a/src/layouts/RatingPopUpLayout/RatingPopUpLayout.tsx
+++ b/src/layouts/RatingPopUpLayout/RatingPopUpLayout.tsx
@@ -7,7 +7,7 @@ import type { AchievementList } from "feature/achievements";
 import { AchievementCard, useAchievementContext } from "feature/achievements";
 import type { ReportDataInterface } from "feature/user/view/ReportView/ReportView.types";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowRight, Brain, Ear, Flame, Hand, Music, RotateCcw, Sparkles, Timer, Trophy } from "lucide-react";
+import { ArrowRight, Brain, Ear, Flame, Hand, Music, RotateCcw, Sparkles, Swords, Timer, Trophy } from "lucide-react";
 import Router from "next/router";
 import { useMemo } from "react";
 import {
@@ -116,8 +116,13 @@ const RatingPopUpLayout = ({
   } = useRatingPopUp({ ratingData, currentUserStats, previousUserStats, activityData });
 
   const fame = ratingData.fameEarned ?? 0;
+  // Part of `fame`, not an extra on top — it gets its own chip because the gear
+  // that earned it is the one thing the player can act on.
+  const rigBonus = ratingData.fameRigBonus ?? 0;
   // Fame scales on a curve over the day's practice total, so spell out the parts
-  // that aren't just "time" — otherwise the number looks arbitrary.
+  // that aren't just "time" — otherwise the number looks arbitrary. The rig's
+  // rate belongs in the Arsenal, where it can be acted on; here it was only ever
+  // read as a second, contradictory number next to the chip.
   const fameBreakdown = [
     (ratingData.fameStreakBonus ?? 0) > 0 ? `+${ratingData.fameStreakBonus} streak bonus` : null,
     ratingData.fameAccuracyBonus ? "×1.25 accuracy" : null,
@@ -342,10 +347,29 @@ const RatingPopUpLayout = ({
               </div>
 
               {fame > 0 && (
-                <div className="mt-4 inline-flex items-center gap-1.5 rounded bg-amber-500/10 px-3 py-1 text-amber-400">
-                  <img src="/images/coin.png" alt="Fame" className="h-4 w-4 object-contain" />
-                  <span className="text-sm font-bold tabular-nums">+{fame}</span>
-                  <span className="text-sm font-medium">Fame</span>
+                <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+                  <div className="inline-flex items-center gap-1.5 rounded bg-amber-500/10 px-3 py-1 text-amber-400">
+                    <img src="/images/coin.png" alt="Fame" className="h-4 w-4 object-contain" />
+                    <span className="text-sm font-bold tabular-nums">+{fame}</span>
+                    <span className="text-sm font-medium">Fame</span>
+                  </div>
+
+                  {/* Amber, like the Fame chip beside it: this *is* Fame, and a
+                      second colour read as a second currency. The crossed swords
+                      carry the Arsenal reference on their own. Delayed so it
+                      lands after the total — the rig arriving as its own beat is
+                      what makes the gear feel responsible for it. */}
+                  {rigBonus > 0 && (
+                    <motion.div
+                      initial={{ opacity: 0, y: 6, scale: 0.94 }}
+                      animate={{ opacity: 1, y: 0, scale: 1 }}
+                      transition={{ delay: 0.9, duration: 0.35, ease: "easeOut" }}
+                      className="inline-flex items-center gap-1.5 rounded bg-amber-500/10 px-3 py-1 text-amber-400">
+                      <Swords size={14} />
+                      <span className="text-sm font-bold tabular-nums">+{rigBonus}</span>
+                      <span className="text-sm font-medium">from your rig</span>
+                    </motion.div>
+                  )}
                 </div>
               )}
 

--- a/src/pages/api/user/report/index.ts
+++ b/src/pages/api/user/report/index.ts
@@ -1,3 +1,4 @@
+import { getRigLevel } from "feature/arsenal/data/rigLevel";
 import { getCurrentSeason } from "feature/leadboard/services/getCurrentSeason";
 import { firebaseAddLogReport } from "feature/logs/services/addLogReport.service";
 import { invalidateActivityLogsCache } from "feature/logs/services/getUserRaprotsLogs.service";
@@ -144,6 +145,15 @@ export default async function handler(
     // Calculate points gained in this session - use the points from current report only
     const pointsGained = report.raitingData.totalPoints || 0;
 
+    // Recomputed from the stored arsenal rather than read off the denormalized
+    // `rigLevel` field: that field is only refreshed by arsenal writes, so a
+    // stale one would pay the wrong rate. The arsenal is already in memory from
+    // `firebaseGetUserData`, so this costs no extra read. Never trust the
+    // request body for it — the payload is client-controlled.
+    const rigLevel = userData?.arsenal
+      ? getRigLevel(userData.arsenal)
+      : (typeof userData?.rigLevel === "number" ? userData.rigLevel : 0);
+
     // Fame no longer mirrors points: it pays out on a concave curve over the
     // user's daily practice total, so short daily sessions beat marathons and
     // the shop economy can't be inflated by one very long (self-reported) day.
@@ -154,6 +164,7 @@ export default async function handler(
       fameDay: currentUserStats.fameDay,
       accuracy: inputData.micPerformance?.accuracy,
       isDateBackReport: report.isDateBackReport,
+      rigLevel,
     });
     const fameEarned = fameResult.fame;
 
@@ -238,6 +249,7 @@ export default async function handler(
         fameEarned,
         fameStreakBonus: fameResult.streakBonus,
         fameAccuracyBonus: fameResult.accuracyBonusApplied,
+        fameRigBonus: fameResult.rigFame,
       },
     });
   }

--- a/src/utils/gameLogic/calculateSessionFame.ts
+++ b/src/utils/gameLogic/calculateSessionFame.ts
@@ -14,7 +14,16 @@
  * Consistency is rewarded with a flat daily bonus (paid once per day) rather
  * than the old streak multiplier, which stacked multiplicatively with session
  * length and paid marathon-plus-streak users the most.
+ *
+ * On top of all that sits the rig bonus — see `feature/arsenal/data/rigFame`.
+ * It rides the same daily-minutes counter, so it inherits the split-proofing
+ * rather than reimplementing it.
  */
+
+import {
+  cumulativeRigFame,
+  getRigFameRate,
+} from "feature/arsenal/data/rigFame";
 
 /** `fame = FAME_CURVE_FACTOR * sqrt(dailyMinutes)` — 1h ≈ 23, 2h ≈ 33, 4h ≈ 46. */
 export const FAME_CURVE_FACTOR = 3;
@@ -64,6 +73,11 @@ export interface SessionFameInput {
   accuracy?: number;
   /** Days back — non-zero marks a back-dated report. */
   isDateBackReport?: number;
+  /**
+   * Total level of the gear the user has in service. Absent or 0 pays no rig
+   * bonus, which is what keeps every pre-rig caller (and its tests) unchanged.
+   */
+  rigLevel?: number;
 }
 
 export interface SessionFameResult {
@@ -73,6 +87,10 @@ export interface SessionFameResult {
   curveFame: number;
   /** The flat streak component (0 when already paid today). */
   streakBonus: number;
+  /** The rig component — what the user's gear paid for this session. */
+  rigFame: number;
+  /** Fame/hour the rig is worth right now, so the UI can show the rate itself. */
+  rigFameRate: number;
   /** Whether the accuracy multiplier applied — the UI can call it out. */
   accuracyBonusApplied: boolean;
   /** The counter to persist. */
@@ -97,17 +115,23 @@ export const calculateSessionFame = ({
   fameDay,
   accuracy,
   isDateBackReport,
+  rigLevel = 0,
 }: SessionFameInput): SessionFameResult => {
   // A counter from an earlier day is stale — the new day starts from zero.
   const isSameDay = fameDay?.date === dayKey;
   const minutesBefore = isSameDay ? Math.max(0, fameDay?.minutes ?? 0) : 0;
   const streakBonusClaimed = isSameDay ? Boolean(fameDay?.streakBonusClaimed) : false;
+  const rigFameRate = getRigFameRate(rigLevel);
 
   if (isDateBackReport) {
     return {
       fame: BACKDATED_REPORT_FAME,
       curveFame: BACKDATED_REPORT_FAME,
       streakBonus: 0,
+      // The rig pays against a day's minutes, and a back-dated report's day is
+      // already closed — there is no counter here for it to read.
+      rigFame: 0,
+      rigFameRate,
       accuracyBonusApplied: false,
       // Untouched: a back-dated report must not consume today's allowance.
       fameDay: { date: dayKey, minutes: minutesBefore, streakBonusClaimed },
@@ -128,10 +152,21 @@ export const calculateSessionFame = ({
   // actually earned something — an empty report shouldn't claim it.
   const streakBonus = !streakBonusClaimed && curveFame > 0 ? getStreakFameBonus(streak) : 0;
 
+  // Read off the same daily counter as the curve, so six short reports pay
+  // exactly what one long one does. `max` guards the one case the monotonicity
+  // argument doesn't cover: a rig rebuilt mid-day changes the rate under us.
+  const rigFame = Math.max(
+    0,
+    cumulativeRigFame(minutesAfter, rigLevel) -
+      cumulativeRigFame(minutesBefore, rigLevel)
+  );
+
   return {
-    fame: curveFame + streakBonus,
+    fame: curveFame + streakBonus + rigFame,
     curveFame,
     streakBonus,
+    rigFame,
+    rigFameRate,
     accuracyBonusApplied,
     fameDay: {
       date: dayKey,

--- a/src/utils/gameLogic/test/calculateSessionFame.test.ts
+++ b/src/utils/gameLogic/test/calculateSessionFame.test.ts
@@ -161,6 +161,95 @@ describe("calculateSessionFame", () => {
     expect(backdated.fameDay).toEqual(earlier.fameDay);
   });
 
+  it("pays no rig bonus when the caller has no rig", () => {
+    const result = session(60);
+
+    expect(result.rigFame).toBe(0);
+    expect(result.rigFameRate).toBe(0);
+  });
+
+  it("adds the rig bonus on top of the curve and the streak", () => {
+    const plain = session(30, { streak: 7 });
+    const geared = session(30, { streak: 7, rigLevel: 750 });
+
+    expect(geared.rigFame).toBeGreaterThan(0);
+    expect(geared.curveFame).toBe(plain.curveFame);
+    expect(geared.streakBonus).toBe(plain.streakBonus);
+    expect(geared.fame).toBe(plain.fame + geared.rigFame);
+  });
+
+  it("gives splitters no rig advantage over one long session", () => {
+    let fameDay = undefined as any;
+    let total = 0;
+
+    for (let i = 0; i < 6; i++) {
+      const result = calculateSessionFame({
+        sessionTimeMs: 20 * MINUTE,
+        dayKey: TODAY,
+        streak: 1,
+        fameDay,
+        rigLevel: 750,
+      });
+      total += result.rigFame;
+      fameDay = result.fameDay;
+    }
+
+    expect(total).toBe(session(120, { rigLevel: 750 }).rigFame);
+  });
+
+  it("never pays a negative rig bonus when the rig changes mid-day", () => {
+    const first = session(20, { rigLevel: 750 });
+    const afterSellingTheRig = calculateSessionFame({
+      sessionTimeMs: 20 * MINUTE,
+      dayKey: TODAY,
+      streak: 1,
+      fameDay: first.fameDay,
+      rigLevel: 40,
+    });
+
+    expect(afterSellingTheRig.rigFame).toBeGreaterThanOrEqual(0);
+  });
+
+  it("pays the rig bonus again on a new day", () => {
+    const yesterday = session(120, { rigLevel: 750 });
+    const today = calculateSessionFame({
+      sessionTimeMs: 30 * MINUTE,
+      dayKey: "2026-08-08",
+      streak: 2,
+      fameDay: yesterday.fameDay,
+      rigLevel: 750,
+    });
+
+    expect(today.rigFame).toBe(session(30, { rigLevel: 750 }).rigFame);
+  });
+
+  it("pays no rig bonus on a back-dated report", () => {
+    const result = session(60, { rigLevel: 750, isDateBackReport: 3 });
+
+    expect(result.fame).toBe(BACKDATED_REPORT_FAME);
+    expect(result.rigFame).toBe(0);
+  });
+
+  it("still reports the rate on a back-dated report so the UI can explain it", () => {
+    expect(session(60, { rigLevel: 750, isDateBackReport: 3 }).rigFameRate).toBeGreaterThan(0);
+  });
+
+  it("keeps practice worth more than gear at the average rig", () => {
+    // Most players sit at rig 100–200, and there the curve has to stay the bigger
+    // half — the rig is a bonus on practising, not a reason to stop.
+    const result = session(25, { rigLevel: 200 });
+
+    expect(result.rigFame).toBeLessThan(result.curveFame);
+  });
+
+  it("lets a top rig out-earn the curve, on purpose", () => {
+    // The other side of that line, pinned so it can't drift back by accident:
+    // 750 is the top rig in the game and it is meant to feel like it.
+    const result = session(25, { rigLevel: 750 });
+
+    expect(result.rigFame).toBeGreaterThan(result.curveFame);
+  });
+
   it("rewards four days of one hour over a single four-hour day", () => {
     const marathon = session(240).fame;
     const spread = [1, 2, 3, 4].reduce((total, day) => {


### PR DESCRIPTION
Rig Level only ordered the gear leaderboard. A player could sink hundreds of Fame
and a stash of parts into builds and mods, watch the number climb, and it never
changed what the game paid them. This turns it into a rate they can read.

```
rate    = min(90, 0.42 * rigLevel^0.75)      // Fame per hour, continuous
rigFame = round(rate * dayMinutes / 60)      // off the same daily counter
```

| rigLevel | rate | 25 min | 60 min |
| --- | --- | --- | --- |
| 100 | 13.3 /h | 6 | 13 |
| 200 (average) | 22.3 /h | 9 | 22 |
| 400 | 37.6 /h | 16 | 38 |
| 750 (top today) | 60.2 /h | 25 | 60 |

## Shape

Three decisions, each replacing something measurably worse:

- **A power curve, not a hyperbola.** An asymptotic `max*r/(r+k)` put the whole
  live range inside its own flat tail — with the top rig at ~750 and the average
  at 100–200, climbing 500 → 750 was worth under 2 Fame/h, so the last third of
  the ladder paid nothing. `r^0.75` keeps rising: the same climb is worth ~16/h,
  and one level at rig 750 is still worth 60% of one at rig 100.
- **No tiers.** Bracketed rates meant nothing happened between brackets, so three
  quarters of the work bought a number that did not move.
- **No minutes cap.** An earlier draft paid only the day's first half hour. That
  bounded the payout but made the advertised rate a lie — a rig reading
  "8.7 Fame/h" handed back 4 Fame for an hour practised, which was the first thing
  anyone noticed. A rate the UI states has to be the rate the game pays.

## Balance

The rig reads off the **same daily counter as the practice curve**, so six short
reports pay exactly what one long one does, and back-dated reports get nothing —
their day is already closed. No Fame without minutes, so gear never substitutes
for practising.

Two lines are pinned by tests so they can't drift by accident: at the average rig
(100–200) the practice curve stays the bigger half, and at the top rig it is
deliberately exceeded.

Worth knowing: unlike `cumulativeDailyFame` this does **not** taper, so long days
pay proportionally — a 4-hour day at the top rig pays 4x a 1-hour day.
`RIG_FAME_COEFF` is linear and is the single knob if that needs pulling back.

## UI

- **Arsenal** — the rate sits inside the Rig Level chip rather than beside it,
  because it is what that number *does*; read apart, the Arsenal's only causal
  link to Fame would be hidden.
- **Session summary** — its own amber chip, matching the Fame chip beside it since
  this *is* Fame (a second colour read as a second currency). Delayed 0.9s so the
  rig lands as its own beat after the total.

## Verification

- `rigFame.test.ts` — 18 cases: the published table, monotonicity, splitters get
  no advantage, an hour pays exactly the advertised rate, ceiling clamp.
- `calculateSessionFame.test.ts` — rig bonus on top of curve and streak, no
  double-pay across a split day, never negative when the rig changes mid-day,
  skipped on back-dated reports.
- Full suite: **1157 passed / 5 skipped**. ESLint clean on every touched file.

Two pre-existing errors remain in files this touches (`Achievements` used before
defined, unused `SkillPointsGained` import) — both verified as predating this
branch and left alone.

No `firestore.rules` change and no new env var: the bonus is derived from
`arsenal`, which the API handler already loads, so there is no extra read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)